### PR TITLE
Metaphlan docs

### DIFF
--- a/src/BiobakeryUtils.jl
+++ b/src/BiobakeryUtils.jl
@@ -4,6 +4,7 @@ export
     import_abundance_tables,
     import_abundance_table,
     clean_abundance_tables,
+    _split_clades,
     taxfilter,
     taxfilter!,
     parsetaxa,

--- a/src/BiobakeryUtils.jl
+++ b/src/BiobakeryUtils.jl
@@ -4,7 +4,6 @@ export
     import_abundance_tables,
     import_abundance_table,
     clean_abundance_tables,
-    _split_clades,
     taxfilter,
     taxfilter!,
     parsetaxa,

--- a/src/metaphlan.jl
+++ b/src/metaphlan.jl
@@ -22,6 +22,24 @@ const shortlevels = (
     s = :species,
     t = :subspecies)
 
+"""
+    _split_clades(clade_string::AbstractString)
+
+Given a string of taxa, separates taxon levels into elements of type Taxon in a vector.
+
+Examples
+≡≡≡≡≡≡≡≡≡≡
+
+```jldoctest _split_clades
+julia> _split_clades("k__Bacteria|p__Actinobacteria|c__Actinobacteria|o__Actinomycetales")
+4-element Vector{Taxon}:
+ Taxon("Bacteria", :kingdom)
+ Taxon("Actinobacteria", :phylum)
+ Taxon("Actinobacteria", :class)
+ Taxon("Actinomycetales", :order)
+```
+"""
+
 function _split_clades(clade_string)
     clades = split(clade_string, '|')
     taxa = Taxon[]

--- a/src/metaphlan.jl
+++ b/src/metaphlan.jl
@@ -190,7 +190,10 @@ end
 """
     parsetaxon(taxstring::AbstractString, taxlevel::Union{Int, Symbol})
 
-    Levels may be given either as numbers or symbols:
+Finds given taxon level in taxa string and returns the clade and level as a Taxon.
+If taxon level not given, function will return last level.
+
+Levels may be given either as numbers or symbols:
 
 - `1` = `:Kingdom`
 - `2` = `:Phylum`
@@ -203,21 +206,16 @@ end
 
 Examples
 ≡≡≡≡≡≡≡≡≡≡
-
-```jldoctest parsetaxa
- julia> parsetaxa("k__Archaea|p__Euryarchaeota|c__Methanobacteria"; throw_error = true)
- 3-element Vector{Tuple{String, Symbol}}:
- ("Archaea", :kingdom)
- ("Euryarchaeota", :phylum)
- ("Methanobacteria", :class)
- ```
  
- ```jldoctest parsetaxon
- julia> parsetaxon("k__Archaea|p__Euryarchaeota|c__Methanobacteria", 2)
- ("Euryarchaeota", :phylum)
+```jldoctest parsetaxon
+julia> parsetaxon("k__Archaea|p__Euryarchaeota|c__Methanobacteria", 2)
+Taxon("Euryarchaeota", :phylum)
 
- julia> parsetaxon("k__Archaea|p__Euryarchaeota|c__Methanobacteria")
- ("Methanobacteria", :class)
+julia> parsetaxon("k__Archaea|p__Euryarchaeota|c__Methanobacteria", :kingdom)
+Taxon("Archaea", :kingdom)
+
+julia> parsetaxon("k__Archaea|p__Euryarchaeota|c__Methanobacteria")
+Taxon("Methanobacteria", :class)
 ```
 """
 function parsetaxon(taxstring::AbstractString; throw_error=true)
@@ -232,6 +230,23 @@ function parsetaxon(taxstring::AbstractString, taxlevel::Int; throw_error=true)
 end
 
 parsetaxon(taxstring::AbstractString, taxlevel::Symbol) = parsetaxon(taxstring, taxonlevels[taxlevel])
+
+"""
+    parsetaxa(taxstring::AbstractString; throw_error=true)
+
+Given a string of taxa, separates taxon levels into elements of type Taxon in a vector.
+
+Examples
+≡≡≡≡≡≡≡≡≡≡
+
+```jldoctest parsetaxa
+julia> parsetaxa("k__Archaea|p__Euryarchaeota|c__Methanobacteria"; throw_error = true)
+3-element Vector{Taxon}:
+ Taxon("Archaea", :kingdom)
+ Taxon("Euryarchaeota", :phylum)
+ Taxon("Methanobacteria", :class)
+```
+"""
 
 function parsetaxa(taxstring::AbstractString; throw_error=true)
     taxa = split(taxstring, '|')

--- a/src/metaphlan.jl
+++ b/src/metaphlan.jl
@@ -22,24 +22,6 @@ const shortlevels = (
     s = :species,
     t = :subspecies)
 
-"""
-    _split_clades(clade_string::AbstractString)
-
-Given a string of taxa, separates taxon levels into elements of type Taxon in a vector.
-
-Examples
-≡≡≡≡≡≡≡≡≡≡
-
-```jldoctest _split_clades
-julia> _split_clades("k__Bacteria|p__Actinobacteria|c__Actinobacteria|o__Actinomycetales")
-4-element Vector{Taxon}:
- Taxon("Bacteria", :kingdom)
- Taxon("Actinobacteria", :phylum)
- Taxon("Actinobacteria", :class)
- Taxon("Actinomycetales", :order)
-```
-"""
-
 function _split_clades(clade_string)
     clades = split(clade_string, '|')
     taxa = Taxon[]

--- a/src/metaphlan.jl
+++ b/src/metaphlan.jl
@@ -58,14 +58,14 @@ end
 Filter a MetaPhlAn table (as DataFrame) to a particular taxon level.
 Levels may be given either as numbers or symbols:
 
-- `1` = `:Kingdom`
-- `2` = `:Phylum`
-- `3` = `:Class`
-- `4` = `:Order`
-- `5` = `:Family`
-- `6` = `:Genus`
-- `7` = `:Species`
-- `8` = `:Subspecies`
+- `1` = `:kingdom`
+- `2` = `:phylum`
+- `3` = `:class`
+- `4` = `:order`
+- `5` = `:family`
+- `6` = `:genus`
+- `7` = `:species`
+- `8` = `:subspecies`
 
 Taxon level is removed from resulting taxon string, eg.
 `g__Bifidobacterium` becomes `Bifidobacterium`.
@@ -172,19 +172,19 @@ end
 """
     parsetaxon(taxstring::AbstractString, taxlevel::Union{Int, Symbol})
 
-Finds given taxon level in taxa string and returns the clade and level as a Taxon.
-If taxon level not given, function will return last level.
+Finds given taxonomic level in a string (as formatted by MetaPhlAn (eg "k__Bacteria|p__Proteobacteria...")) and returns the clade and taxonomic level as a Taxon.
+If taxon level not given, function will return the most specific (lowest) taxonomic level available.
 
 Levels may be given either as numbers or symbols:
 
-- `1` = `:Kingdom`
-- `2` = `:Phylum`
-- `3` = `:Class`
-- `4` = `:Order`
-- `5` = `:Family`
-- `6` = `:Genus`
-- `7` = `:Species`
-- `8` = `:Subspecies`
+- `1` = `:kingdom`
+- `2` = `:phylum`
+- `3` = `:class`
+- `4` = `:order`
+- `5` = `:family`
+- `6` = `:genus`
+- `7` = `:species`
+- `8` = `:subspecies`
 
 Examples
 ≡≡≡≡≡≡≡≡≡≡
@@ -216,7 +216,7 @@ parsetaxon(taxstring::AbstractString, taxlevel::Symbol) = parsetaxon(taxstring, 
 """
     parsetaxa(taxstring::AbstractString; throw_error=true)
 
-Given a string of taxa, separates taxon levels into elements of type Taxon in a vector.
+Given a string representing taxonmic levels as formatted by MetaPhlAn (eg "k__Bacteria|p__Proteobacteria..."), separates taxonomic levels into elements of type Taxon in a vector.
 
 Examples
 ≡≡≡≡≡≡≡≡≡≡
@@ -229,7 +229,6 @@ julia> parsetaxa("k__Archaea|p__Euryarchaeota|c__Methanobacteria"; throw_error =
  Taxon("Methanobacteria", :class)
 ```
 """
-
 function parsetaxa(taxstring::AbstractString; throw_error=true)
     taxa = split(taxstring, '|')
     return map(t-> Taxon(t...), _shortname.(taxa, throw_error=throw_error))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,10 @@ using DelimitedFiles
 using CSV
 
 @testset "Metaphlan" begin
+    clades = _split_clades("k__Archaea|p__Euryarchaeota|c__Methanobacteria|o__Methanobacteriales|f__Methanobacteriaceae|g__Methanosphaera|s__Methanosphaera_stadtmanae|t__GCF_000012545")
+    @test length(clades) == 8
+    @test clades[3] == Taxon("Methanobacteria", :class)
+
     @test parsetaxon("k__Archaea|p__Euryarchaeota|c__Methanobacteria", 2) == Taxon("Euryarchaeota", :phylum)
     @test parsetaxon("k__Archaea|p__Euryarchaeota|c__Methanobacteria") == Taxon("Methanobacteria", :class)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,10 +9,6 @@ using DelimitedFiles
 using CSV
 
 @testset "Metaphlan" begin
-    clades = _split_clades("k__Archaea|p__Euryarchaeota|c__Methanobacteria|o__Methanobacteriales|f__Methanobacteriaceae|g__Methanosphaera|s__Methanosphaera_stadtmanae|t__GCF_000012545")
-    @test length(clades) == 8
-    @test clades[3] == Taxon("Methanobacteria", :class)
-
     taxstring = "k__Archaea|p__Euryarchaeota|c__Methanobacteria|o__Methanobacteriales|f__Methanobacteriaceae|g__Methanobrevibacter|s__Methanobrevibacter_smithii"
     taxa = parsetaxa(taxstring)
     @test length(taxa) == 7

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,14 @@ using CSV
     @test length(clades) == 8
     @test clades[3] == Taxon("Methanobacteria", :class)
 
+    taxstring = "k__Archaea|p__Euryarchaeota|c__Methanobacteria|o__Methanobacteriales|f__Methanobacteriaceae|g__Methanobrevibacter|s__Methanobrevibacter_smithii"
+    taxa = parsetaxa(taxstring)
+    @test length(taxa) == 7
+    @test parsetaxon(taxstring, 1) == Taxon("Archaea", :kingdom)
+    @test parsetaxon(taxstring, :family) == Taxon("Methanobacteriaceae", :family)
+    @test parsetaxon(taxstring) == Taxon("Methanobrevibacter_smithii", :species)
+    @test_throws ArgumentError parsetaxon(taxstring, 8)
+
     @test parsetaxon("k__Archaea|p__Euryarchaeota|c__Methanobacteria", 2) == Taxon("Euryarchaeota", :phylum)
     @test parsetaxon("k__Archaea|p__Euryarchaeota|c__Methanobacteria") == Taxon("Methanobacteria", :class)
 end


### PR DESCRIPTION
added some documentation and unit tests for metaphlan.jl.
- modified docs and added tests for `parsetaxon` and `parsetaxa`
- added docs and tests for `_split_clades` before realizing that's not actually exported so i deleted them

I'm not sure whether or not the functions that are not exported need docs and test. If so, I can add them