### PR TITLE
change contributing link

### DIFF
--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -1,7 +1,7 @@
 # Contributing
 
 The BioJulia organisation has a set of contribution guidelines which apply to
-all BioJulia projects. These guidelines are available [here](http://biojulia.github.io/Contributing/latest) and it is
+all BioJulia projects. These guidelines are available [here](/CONTRIBUTING.md) and it is
 recommended all new contributors read these guidelines before opening a pull
 request.
 

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -1,16 +1,15 @@
 # Contributing
 
 The BioJulia organisation has a set of contribution guidelines which apply to
-all BioJulia projects. These guidelines are available [here](/CONTRIBUTING.md) and it is
+all BioJulia projects. These guidelines are available [here](https://github.com/BioJulia/Contributing/blob/master/CONTRIBUTING.md) and it is
 recommended all new contributors read these guidelines before opening a pull
 request.
 
 ## Making a contribution
 
 If you're interested in adding functionality to BiobakeryUtils.jl, please feel free
-to open an issue or a pull request (PR) against the `master` branch. If you're
-not yet ready for that, you can also ask questions/start a discussion in the
-[Bio.jl](https://gitter.im/BioJulia/Bio.jl) gitter channel.
+to open an issue or a pull request (PR) against the `main` branch. If you're
+not yet ready for that, you can also ask questions/start a discussion in the `#biology` channel on [slack or zulip](https://julialang.org/community/), or using the [`biology` domain on discourse](https://discourse.julialang.org/c/domain/bio/).
 
 Work-in-progress PRs are fine, as discussion about approach and code review
 can happen in the PR.


### PR DESCRIPTION
I just changed the link to go to `CONTRIBUTING.md` in the repo. I think this is what BioJulia/Microbiome.jl#69 is asking for?